### PR TITLE
Hotfix/type error utf encoding

### DIFF
--- a/flair_bot.py
+++ b/flair_bot.py
@@ -1,11 +1,16 @@
 """ Flair bot. """
 import sys
 import os
-import io
 import csv
 from configparser import ConfigParser
 from time import gmtime, strftime
 import praw
+
+req_version = (2,6)
+cur_version = sys.version_info
+
+if (cur_version >= req_version) and (cur_version < (3,0)):
+    import io
 
 class FlairBot:
     """ Flair bot. """

--- a/flair_bot.py
+++ b/flair_bot.py
@@ -1,6 +1,7 @@
 """ Flair bot. """
 import sys
 import os
+import io
 import csv
 from configparser import ConfigParser
 from time import gmtime, strftime
@@ -105,7 +106,7 @@ class FlairBot:
     def log(user, text, cls):
         """ Log applied flairs to file. """
 
-        with open('log.txt', 'a', encoding='utf-8') as logfile:
+        with io.open('log.txt', 'a', encoding='utf-8') as logfile:
             time_now = strftime("%Y-%m-%d %H:%M:%S", gmtime())
             log = 'user: ' + user
             log += ' | class(es): ' + cls

--- a/flair_bot.py
+++ b/flair_bot.py
@@ -6,7 +6,7 @@ from configparser import ConfigParser
 from time import gmtime, strftime
 import praw
 
-req_version = (2,6)
+req_version = (2,7)
 cur_version = sys.version_info
 
 if (cur_version >= req_version) and (cur_version < (3,0)):


### PR DESCRIPTION
While this script is intended for Python 3 and above; utilizing the `io` module's `open()` function when writing to logs extends compatibility to Python 2.7 and above. Previously, log writes from this script executed in 2.7 environments would not accept the `encoding` argument. This resulted in a `TypeError` and improperly encoded writes.

* Lines 9-14 checks the current system Python version and conditionally import the `io` module, when needed.
* Line 108 now references the [`io.open()` alias](https://docs.python.org/3.6/library/io.html#io.open) for the built in function `open()`, eliminating a need for conditionality anywhere except the importing of the io module.